### PR TITLE
`__future__.division` has been supplanted since Python 3.0

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import math
 import time
 import tqdm


### PR DESCRIPTION
According to the table embedded in [the official doc of `__future__` standard library](https://docs.python.org/3/library/__future__.html), the `__future__.division` feature has become mandatory since 3.0, hence supplanted.

Python 2.x has [reached EOL since 2020.1.1](https://pythonclock.org/). If someone were to use a Python 2.x distribution to run the everest project, he has a bigger problem. It's better to fail fast and early in such case.